### PR TITLE
Add true Predicate to avoid crash

### DIFF
--- a/src/main/java/org/ladysnake/creeperspores/mixin/BoneMealItemMixin.java
+++ b/src/main/java/org/ladysnake/creeperspores/mixin/BoneMealItemMixin.java
@@ -35,7 +35,7 @@ public abstract class BoneMealItemMixin {
     @Inject(method = "useOnFertilizable", at = @At("RETURN"), cancellable = true)
     private static void fertilizeCreeperlings(ItemStack boneMeal, World world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         if (!cir.getReturnValueZ()) {
-            List<CreeperlingEntity> creeperlings = world.getEntitiesByClass(CreeperlingEntity.class, new Box(pos), null);
+            List<CreeperlingEntity> creeperlings = world.getEntitiesByClass(CreeperlingEntity.class, new Box(pos), (entity) -> true);
             if (!creeperlings.isEmpty()) {
                 creeperlings.get(0).applyFertilizer(boneMeal);
                 cir.setReturnValue(true);


### PR DESCRIPTION
Solves #27

When getting entities of class, the World checks the predicate supplied here. There's never a null check on that predicate (and it's not marked nullable), so this was causing a crash by trying to run a predicate test on a null predicate. Adding a simple true predicate should resolve this and avoid the crash!